### PR TITLE
bump: update otel-collector-contrib image to v0.114.0

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/templates/otel_collect_deployment.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/otel_collect_deployment.tpl
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: otel-collector 
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.114.0
+          image: otel/opentelemetry-collector-contrib:0.120.0
           args:
             - "--config=/etc/otelcol-contrib/config.yaml"
           volumeMounts:

--- a/hotelReservation/helm-chart/hotelreservation/templates/otel_collect_deployment.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/otel_collect_deployment.tpl
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: otel-collector 
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.85.0
+          image: otel/opentelemetry-collector-contrib:0.114.0
           args:
             - "--config=/etc/otelcol-contrib/config.yaml"
           volumeMounts:

--- a/hotelReservation/helm-chart/hotelreservation/templates/otel_collector_config.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/otel_collector_config.tpl
@@ -128,7 +128,7 @@ data:
               static_configs:
                 - targets: ['0.0.0.0:8888']
     exporters:
-      logging:
+      debug:
       otlp:
         endpoint: "{{ .Values.global.monitoring.centralJaegerAddress }}:4317"
         tls:
@@ -206,12 +206,12 @@ data:
         traces:
           receivers: [otlp, jaeger]
           processors: [k8sattributes, memory_limiter, resource, transform, batch]
-          exporters: [otlp, logging, spanmetrics]
+          exporters: [otlp, debug, spanmetrics]
         metrics:
           receivers: [hostmetrics, otlp, prometheus, spanmetrics]
           processors: [k8sattributes, memory_limiter, resource, batch]
-          exporters: [otlphttp/prometheus, logging]
+          exporters: [otlphttp/prometheus, debug]
         logs:
           receivers: [otlp]
           processors: [k8sattributes, memory_limiter, resource, batch]
-          exporters: [logging]
+          exporters: [debug]


### PR DESCRIPTION
This PR updates the `otel-collector-contrib` image to v0.114.0.