### PR TITLE
fix: rename otel collector service name values

### DIFF
--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeployment.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeployment.tpl
@@ -53,9 +53,9 @@ spec:
                   fieldPath: status.hostIP
             # OpenTelemetry specific environment variables
             - name: OTEL_SERVICE_NAME
-              value: {{ $.Values.name | default $.Chart.Name | quote }}
+              value: {{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}"
+              value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}"
             {{- if .environments }}
             {{- range $e := .environments }}
             - name: {{ $e.name }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentMemcached.tpl
@@ -69,9 +69,9 @@ spec:
                 fieldPath: status.hostIP
           # OpenTelemetry specific environment variables
           - name: OTEL_SERVICE_NAME
-            value: {{ $.Values.name | default $.Chart.Name | quote }}
+            value: {{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}
           - name: OTEL_RESOURCE_ATTRIBUTES
-            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}"
+            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}"
           {{- range $variable, $value := .environments }}
           - name: {{ $variable }}
             value: {{ $value | quote }}
@@ -101,9 +101,9 @@ spec:
                 fieldPath: status.hostIP
           # OpenTelemetry specific environment variables
           - name: OTEL_SERVICE_NAME
-            value: {{ $.Values.name | default $.Chart.Name | quote }}
+            value: {{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}
           - name: OTEL_RESOURCE_ATTRIBUTES
-            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}"
+            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}"
           {{- range $variable, $value := $.Values.global.memcached.environments }}
           - name: {{ $variable }}
             value: {{ $value | quote }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/_baseDeploymentServices.tpl
@@ -83,9 +83,9 @@ spec:
                 fieldPath: status.hostIP
           # OpenTelemetry specific environment variables
           - name: OTEL_SERVICE_NAME
-            value: {{ $.Values.name | default $.Chart.Name | quote }}
+            value: {{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}
           - name: OTEL_RESOURCE_ATTRIBUTES
-            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}"
+            value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(NODE_NAME),k8s.pod.ip=$(POD_IP),service.name={{ $.Values.name | default $.Chart.Name }}-{{ $.Release.Name }}"
           {{- range $variable, $value := $.Values.global.services.environments }}
           - name: {{ $variable }}
             value: {{ $value | quote }}

--- a/hotelReservation/helm-chart/hotelreservation/templates/otel_collector_config.tpl
+++ b/hotelReservation/helm-chart/hotelreservation/templates/otel_collector_config.tpl
@@ -146,6 +146,17 @@ data:
             statements:
               - replace_pattern(name, "\\?.*", "")
               - replace_match(name, "GET /api/products/*", "GET /api/products/{productId}")
+          - context: resource
+            statements:
+              - set(resource.attributes["service.name"], "consul-{{ .Release.Name }}") where resource.attributes["service.name"] == "consul"
+              - set(resource.attributes["service.name"], "frontend-{{ .Release.Name }}") where resource.attributes["service.name"] == "frontend"
+              - set(resource.attributes["service.name"], "geo-{{ .Release.Name }}") where resource.attributes["service.name"] == "geo"
+              - set(resource.attributes["service.name"], "profile-{{ .Release.Name }}") where resource.attributes["service.name"] == "profile"
+              - set(resource.attributes["service.name"], "rate-{{ .Release.Name }}") where resource.attributes["service.name"] == "rate"
+              - set(resource.attributes["service.name"], "recommendation-{{ .Release.Name }}") where resource.attributes["service.name"] == "recommendation"
+              - set(resource.attributes["service.name"], "reservation-{{ .Release.Name }}") where resource.attributes["service.name"] == "reservation"
+              - set(resource.attributes["service.name"], "search-{{ .Release.Name }}") where resource.attributes["service.name"] == "search"
+              - set(resource.attributes["service.name"], "user-{{ .Release.Name }}") where resource.attributes["service.name"] == "user"
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false


### PR DESCRIPTION
This PR removes the `fullname` for the object name.